### PR TITLE
macOS: Add fix for ModifiersChanged relocation

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -762,6 +762,8 @@ extern "C" fn flags_changed(this: &Object, _sel: Sel, event: id) {
             }));
         }
 
+        trace!("Queueing event with modifiers {:?}", state.modifiers);
+
         AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
             // TODO Maybe memoize get_window_id if it's safe to reuse?
             window_id: WindowId(get_window_id(state.ns_window)),

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -762,9 +762,10 @@ extern "C" fn flags_changed(this: &Object, _sel: Sel, event: id) {
             }));
         }
 
-        AppState::queue_event(EventWrapper::StaticEvent(Event::DeviceEvent {
-            device_id: DEVICE_ID,
-            event: DeviceEvent::ModifiersChanged(state.modifiers),
+        AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
+            // TODO Maybe memoize get_window_id if it's safe to reuse?
+            window_id: WindowId(get_window_id(state.ns_window)),
+            event: WindowEvent::ModifiersChanged(state.modifiers),
         }));
     }
     trace!("Completed `flagsChanged`");

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -16,7 +16,7 @@ use objc::{
 
 use crate::{
     dpi::LogicalSize,
-    event::{Event, WindowEvent},
+    event::{Event, ModifiersState, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
         event::{EventProxy, EventWrapper},
@@ -319,6 +319,7 @@ extern "C" fn window_did_become_key(this: &Object, _: Sel, _: id) {
 extern "C" fn window_did_resign_key(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowDidResignKey:`");
     with_state(this, |state| {
+        state.emit_event(WindowEvent::ModifiersChanged(ModifiersState::empty()));
         state.emit_event(WindowEvent::Focused(false));
     });
     trace!("Completed `windowDidResignKey:`");


### PR DESCRIPTION
(I've removed the checklist here because it didn't seem too important.)

This PR:
- Makes macOS build happily again simply by re-pointing the `DeviceEvent` elsewhere.
- Adds a call in the WindowDelegate to send an empty list of modifiers after the window loses focus.
  - I'm not aware of a way on macOS that you can switch to a window and still have modifiers held down.

I tested this by running the `window_debug` example and observing traces, which have since been removed.