### PR TITLE
windows: Send ModifiersChanged(ModifiersState::empty) on KILLFOCUS

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1357,7 +1357,11 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
         }
 
         winuser::WM_KILLFOCUS => {
-            use crate::event::{ElementState::Released, WindowEvent::Focused};
+            use crate::event::{
+                ElementState::Released,
+                ModifiersState,
+                WindowEvent::{Focused, ModifiersChanged},
+            };
             for windows_keycode in event::get_pressed_keys() {
                 let scancode =
                     winuser::MapVirtualKeyA(windows_keycode as _, winuser::MAPVK_VK_TO_VSC);
@@ -1378,6 +1382,11 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     },
                 })
             }
+
+            subclass_input.send_event(Event::WindowEvent {
+                window_id: RootWindowId(WindowId(window)),
+                event: ModifiersChanged(ModifiersState::empty()),
+            });
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),


### PR DESCRIPTION
Very similar to the changes made in f79f21641a31da3e4039d41be89047cdcc6028f7, as focus is lost, send an event to the window indicating that the modifiers have been released.

It's unclear to me (without a Windows device to test this on) whether this is necessary, but it certainly ensures that unfocused windows will have at least received this event, which doesn't seem unexpected.