### PR TITLE
Last two additional bits of state checking

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -909,6 +909,8 @@ fn mouse_motion(this: &Object, event: id) {
             return;
         }
 
+        update_potentially_stale_modifiers(state, event);
+
         let x = view_point.x as f64;
         let y = view_rect.size.height as f64 - view_point.y as f64;
         let logical_position = LogicalPosition::new(x, y);

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -706,6 +706,8 @@ extern "C" fn key_up(this: &Object, _sel: Sel, event: id) {
         let scancode = get_scancode(event) as u32;
         let virtual_keycode = retrieve_keycode(event);
 
+        update_potentially_stale_modifiers(state, event);
+
         #[allow(deprecated)]
         let window_event = Event::WindowEvent {
             window_id: WindowId(get_window_id(state.ns_window)),

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -16,7 +16,7 @@ use objc::{
 
 use crate::{
     dpi::LogicalSize,
-    event::{Event, ModifiersState, WindowEvent},
+    event::{Event, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
         event::{EventProxy, EventWrapper},
@@ -319,7 +319,6 @@ extern "C" fn window_did_become_key(this: &Object, _: Sel, _: id) {
 extern "C" fn window_did_resign_key(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowDidResignKey:`");
     with_state(this, |state| {
-        state.emit_event(WindowEvent::ModifiersChanged(ModifiersState::empty()));
         state.emit_event(WindowEvent::Focused(false));
     });
     trace!("Completed `windowDidResignKey:`");


### PR DESCRIPTION
Again, per feedback on the PR.

- Remove the synthetic event, as it is no longer needed.
- In `mouse_motion` and `key_up`, also perform the checks as before. The check is tiny but can have a profound impact on consistency.