### PR TITLE
mouse_motion: Remove update_potentially_stale_modifiers invocation

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -911,8 +911,6 @@ fn mouse_motion(this: &Object, event: id) {
             return;
         }
 
-        update_potentially_stale_modifiers(state, event);
-
         let x = view_point.x as f64;
         let y = view_rect.size.height as f64 - view_point.y as f64;
         let logical_position = LogicalPosition::new(x, y);


### PR DESCRIPTION
Remove `update_potentially_stale_modifiers` invocation from `mouse_motion`, since it seems unlikely that one could have inconsistency in a place like this.